### PR TITLE
feat: BFカメラ接続時の自動ウィンドウアクティブ化機能を追加

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -24,5 +24,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // トレイ・自動起動関連
   onAskAutoStart: (callback) => ipcRenderer.on('ask-auto-start', callback),
   onRefreshCamera: (callback) => ipcRenderer.on('refresh-camera', callback),
-  setAutoStart: (enabled) => ipcRenderer.invoke('set-auto-start', enabled)
+  setAutoStart: (enabled) => ipcRenderer.invoke('set-auto-start', enabled),
+  
+  // カメラ接続イベント
+  onCameraConnected: (callback) => ipcRenderer.on('camera-connected', callback)
 });

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -37,6 +37,12 @@ class SigmaBFCopy {
         window.electronAPI.onRefreshCamera(() => {
             this.startCameraDetection();
         });
+        
+        // カメラ接続イベント
+        window.electronAPI.onCameraConnected((event, cameraInfo) => {
+            console.log('カメラ接続イベントを受信:', cameraInfo);
+            this.handleCameraConnected(cameraInfo);
+        });
     }
 
     updateProgress(progressData) {
@@ -321,6 +327,17 @@ class SigmaBFCopy {
             this.hideSettingsModal();
             alert('設定を保存しました');
         }
+    }
+
+    handleCameraConnected(cameraInfo) {
+        // カメラ情報を更新
+        this.cameraInfo = cameraInfo;
+        
+        // カメラ検知状態を表示
+        this.showCameraDetected(`${cameraInfo.drive}:\\ - ${cameraInfo.label}`);
+        
+        // 通知メッセージを表示（オプション）
+        console.log('Sigma BFカメラが接続されました。ウィンドウをアクティブ化しています。');
     }
 
     showAutoStartDialog() {


### PR DESCRIPTION
## Summary
- BFカメラが接続されたときに自動的にメインウィンドウをアクティブ化する機能を実装

## 実装内容
- **自動カメラ監視**: メインプロセスで5秒間隔でBFカメラの接続状態を監視
- **ウィンドウアクティブ化**: カメラ検知時に以下の処理を実行
  - 最小化されたウィンドウの復元
  - ウィンドウの表示とフォーカス
  - 一時的にトップレベル表示でアクティブ化
- **イベント通知**: カメラ接続をレンダラープロセスに通知し、UI状態を自動更新
- **リソース管理**: アプリ終了時にカメラ監視を適切に停止

## 技術詳細
- `startCameraMonitoring()`: 定期的なカメラ検知とウィンドウアクティブ化
- `activateMainWindow()`: ウィンドウの表示・フォーカス処理
- `camera-connected` イベント: メイン→レンダラープロセス間の通信
- `handleCameraConnected()`: カメラ接続時のUI状態更新

## Test plan
- [x] BFカメラ接続時にウィンドウが自動表示されることを確認
- [x] ウィンドウが最小化状態からも正しく復元されることを確認
- [x] カメラ接続時にUI状態が自動更新されることを確認
- [x] アプリ終了時にカメラ監視が停止されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)