### PR TITLE
fix: コピー完了後のフォルダ名フィールド入力問題を修正

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -293,13 +293,16 @@ class SigmaBFCopy {
             console.log('コピー結果:', result);
 
             if (result.success) {
-                alert(`コピーが完了しました！\n\n写真: ${result.copiedPhotos}ファイル\n動画: ${result.copiedVideos}ファイル\n\n写真: ${result.photoDestPath}\n動画: ${result.videoDestPath}`);
+                // alert削除：フォーカス問題の原因
+                console.log(`コピーが完了しました！写真: ${result.copiedPhotos}ファイル, 動画: ${result.copiedVideos}ファイル`);
+                console.log(`写真: ${result.photoDestPath}`);
+                console.log(`動画: ${result.videoDestPath}`);
             } else {
-                alert(`コピーに失敗しました: ${result.message}`);
+                console.error(`コピーに失敗しました: ${result.message}`);
             }
         } catch (error) {
             console.error('コピーエラー:', error);
-            alert(`コピー中にエラーが発生しました: ${error.message}`);
+            console.error(`コピー中にエラーが発生しました: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
## Summary
• コピー完了後にフォルダ名フィールドが入力不可になる問題を修正
• 設定保存時と同様のalertダイアログによるフォーカス問題を解決
• alertをconsole.logに変更してユーザビリティを向上

## Test plan
- [ ] フォルダ名を入力してコピー実行
- [ ] コピー完了後にフォルダ名フィールドをクリック
- [ ] フォルダ名フィールドに文字入力ができることを確認
- [ ] alertダイアログが表示されないことを確認
- [ ] コンソールログでコピー結果が確認できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)