### PR TITLE
対象ファイルがない場合のフォルダ作成を修正

### DIFF
--- a/src/utils/file-manager.js
+++ b/src/utils/file-manager.js
@@ -150,7 +150,7 @@ async function copyFiles(sourceFolderPath, photoDestination, videoDestination, f
       
       if (fileType === 'photo') {
         hasPhotos = true;
-      } else {
+      } else if (fileType === 'video') {
         hasVideos = true;
       }
     }
@@ -169,7 +169,7 @@ async function copyFiles(sourceFolderPath, photoDestination, videoDestination, f
       
       if (fileType === 'photo') {
         destPath = path.join(photoDestPath, fileName);
-      } else {
+      } else { // fileType === 'video'
         destPath = path.join(videoDestPath, fileName);
       }
 
@@ -182,7 +182,7 @@ async function copyFiles(sourceFolderPath, photoDestination, videoDestination, f
         
         if (fileType === 'photo') {
           copyResults.copiedPhotos++;
-        } else {
+        } else { // fileType === 'video'
           copyResults.copiedVideos++;
         }
         

--- a/src/utils/file-manager.js
+++ b/src/utils/file-manager.js
@@ -101,7 +101,7 @@ function formatFileSize(bytes) {
   return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
 }
 
-async function copyFiles(sourceFolderPath, photoDestination, videoDestination, folderName) {
+async function copyFiles(sourceFolderPath, photoDestination, videoDestination, folderName, progressCallback) {
   // テストで要求されたファイルコピー機能を実装
   const fs = require('fs-extra');
   const path = require('path');
@@ -164,6 +164,7 @@ async function copyFiles(sourceFolderPath, photoDestination, videoDestination, f
     }
 
     // ファイルをコピー
+    let copiedCount = 0;
     for (const { fileName, sourceFilePath, fileType } of filesToCopy) {
       let destPath;
       
@@ -186,7 +187,19 @@ async function copyFiles(sourceFolderPath, photoDestination, videoDestination, f
           copyResults.copiedVideos++;
         }
         
-        console.log(`コピー完了: ${fileName} -> ${fileType}`);
+        copiedCount++;
+        
+        // 進行状況をコールバック
+        if (progressCallback) {
+          progressCallback({
+            current: copiedCount,
+            total: copyResults.totalFiles,
+            fileName: fileName,
+            percentage: Math.round((copiedCount / copyResults.totalFiles) * 100)
+          });
+        }
+        
+        console.log(`コピー完了: ${fileName} -> ${fileType} (${copiedCount}/${copyResults.totalFiles})`);
         
       } catch (error) {
         console.error(`ファイルコピーエラー: ${fileName}`, error);


### PR DESCRIPTION
## Summary

- 対象ファイルがないときもフォルダが作成される問題を修正
- copyFiles関数で事前ファイルスキャンを実装
- 写真・動画ファイルが存在する場合のみ対応フォルダを作成

## Test plan
-  [ ] 新しいテストケースが通ることを確認
-  [ ] 既存のテストが通ることを確認
-  [ ] 実際にアプリを実行して動作確認

Fixes #22

Generated with [Claude Code](https://claude.ai/code)