### PR TITLE
refactor: restoreFolderName()関数の完全削除

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -11,7 +11,6 @@ class SigmaBFCopy {
         this.setupEventListeners();
         this.setupCopyProgressListener();
         this.setupTrayListeners();
-        // this.restoreFolderName(); // 無効化：イベント干渉の可能性
         
         if (!this.config || this.config.isFirstRun !== false) {
             this.showInitialSetup();
@@ -91,11 +90,6 @@ class SigmaBFCopy {
 
     }
 
-    // restoreFolderName() {
-    //     // フィールド名復元機能を無効化
-    //     // イベント干渉の可能性があるため一時的に無効化
-    //     console.log('フォルダ名復元機能は無効化されています');
-    // }
 
 
     async selectFolder(inputId) {
@@ -315,8 +309,6 @@ class SigmaBFCopy {
 
     hideSettingsModal() {
         document.getElementById('settings-modal').classList.add('hidden');
-        // this.restoreFolderName(); // 無効化：イベント干渉の可能性
-        
     }
 
     async saveSettings() {


### PR DESCRIPTION
## 概要

ユーザーからのご指摘に基づき、不要なrestoreFolderName()関数を完全に削除しました。

## 変更内容

- コメントアウトされていたrestoreFolderName()関数とその呼び出しを削除
- イベント干渉を避けるため既に無効化されていた不要なコードを整理
- lastFolderName保存機能は既存の実装で正常に動作中

Fixes #24

Generated with [Claude Code](https://claude.ai/code)