### PR TITLE
feat: ファイル上書き防止機能を追加

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -18,6 +18,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   copyFiles: (sourceFolder, photoDestination, videoDestination, folderName) => 
     ipcRenderer.invoke('copy-files', sourceFolder, photoDestination, videoDestination, folderName),
   
+  // 強制ファイルコピー（衝突無視）
+  copyFilesForce: (sourceFolder, photoDestination, videoDestination, folderName) => 
+    ipcRenderer.invoke('copy-files-force', sourceFolder, photoDestination, videoDestination, folderName),
+  
   // 進行状況イベント
   onCopyProgress: (callback) => ipcRenderer.on('copy-progress', callback),
   


### PR DESCRIPTION
## 概要

同名ファイルがある場合に警告してコピーを開始しないようにする機能を追加しました。

## 変更内容

- TDDアプローチでテストを先に作成
- checkFileConflicts/checkFolderConflictsで衝突検知機能を実装
- copyFilesWithConflictCheckで衝突チェック付きコピー機能を追加
- 衝突検出時の詳細警告ダイアログをUIに実装
- ユーザー確認による続行/キャンセル選択機能を追加

Closes #25

Generated with [Claude Code](https://claude.ai/code)