### PR TITLE
feat: issue #44 フォルダの日付は元のフォルダから取得

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bf-copy",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bf-copy",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bf-copy",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "BF Camera File Copy Application",
   "main": "src/main/main.js",
   "scripts": {

--- a/src/utils/file-manager.js
+++ b/src/utils/file-manager.js
@@ -90,7 +90,7 @@ function parseFolderDate(folderName) {
     return `${year}-${month}-${day}`;
   }
   
-  return folderName; // 日付形式でない場合はそのまま返す
+  return null; // 日付形式でない場合はnullを返す
 }
 
 function formatFileSize(bytes) {
@@ -114,9 +114,13 @@ async function copyFiles(sourceFolderPath, photoDestination, videoDestination, f
       folderName
     });
 
-    // コピー先フォルダパスを生成
-    const photoDestPath = generateDestinationPath(photoDestination, folderName);
-    const videoDestPath = generateDestinationPath(videoDestination, folderName);
+    // ソースフォルダ名から日付を抽出
+    const sourceFolderName = path.basename(sourceFolderPath);
+    const sourceDate = parseFolderDate(sourceFolderName);
+    
+    // コピー先フォルダパスを生成（元フォルダの日付を使用）
+    const photoDestPath = generateDestinationPath(photoDestination, folderName, sourceDate);
+    const videoDestPath = generateDestinationPath(videoDestination, folderName, sourceDate);
 
     // 上書禁止: 既存フォルダの存在チェック
     const overwriteCheck = await checkForExistingFolders(photoDestPath, videoDestPath, sourceFolderPath);
@@ -252,12 +256,12 @@ function classifyFileType(fileName) {
   }
 }
 
-function generateDestinationPath(destination, folderName) {
+function generateDestinationPath(destination, folderName, sourceDate) {
   // テストで要求されたコピー先パス生成機能を実装
-  // "YYYY-MM-DD_フォルダ名/BF" 形式でフォルダパスを生成
+  // sourceDateが指定されている場合はそれを使用、されていない場合は今日の日付を使用
   const path = require('path');
-  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  const destFolderName = `${today}_${folderName}`;
+  const dateToUse = sourceDate || new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const destFolderName = `${dateToUse}_${folderName}`;
   return path.join(destination, destFolderName, 'BF');
 }
 


### PR DESCRIPTION
## 概要
issue #44の対応として、カメラフォルダの撮影日を使用してコピー先フォルダ名を生成する機能を実装しました。

## 変更内容
- **generateDestinationPath関数の拡張**: sourceDate引数を追加し、元フォルダの日付を使用可能に
- **copyFiles関数の更新**: ソースフォルダ名から日付を抽出してgenerateDestinationPathに渡す
- **parseFolderDate関数の調整**: カメラフォルダ形式でない場合はnullを返すように変更

## 動作仕様
- **カメラフォルダ（YYMMDD_N形式）の場合**: 元フォルダの日付を使用
  - 例: 250518_0 → 2025-05-18_ユーザー入力名
- **通常フォルダの場合**: 従来通り現在の日付を使用
  - 例: test-folder → 2025-08-03_ユーザー入力名

## テスト
- TDD手順（Red-Green-Refactor）に従って実装
- 新機能のテスト2件を追加
- 既存テストも新しい仕様に対応して修正
- 全15件のテストが通過

## ビルド
- v1.0.8としてビルド完了
- 新機能が含まれたWindows版実行ファイルを生成

Closes #44

🤖 Generated with [Claude Code](https://claude.ai/code)