### PR TITLE
feat: 同日複数回コピー対応（差分コピー機能） #50

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -339,11 +339,23 @@ class SigmaBFCopy {
                 console.log(`コピーが完了しました！写真: ${result.copiedPhotos}ファイル, 動画: ${result.copiedVideos}ファイル`);
                 console.log(`写真: ${result.photoDestPath}`);
                 console.log(`動画: ${result.videoDestPath}`);
-                this.showNotification('success', 'コピー完了', `写真: ${result.copiedPhotos}ファイル, 動画: ${result.copiedVideos}ファイルのコピーが完了しました`);
+                
+                // 差分コピーの結果に応じてメッセージを分岐
+                if (result.alreadyExists && (result.skippedPhotos > 0 || result.skippedVideos > 0)) {
+                    // 差分コピーの場合
+                    let message = `差分コピーが完了しました\n\n`;
+                    message += `新規コピー: 写真 ${result.copiedPhotos}ファイル, 動画 ${result.copiedVideos}ファイル\n`;
+                    message += `スキップ: 写真 ${result.skippedPhotos}ファイル, 動画 ${result.skippedVideos}ファイル`;
+                    
+                    this.showNotification('success', '差分コピー完了', message);
+                } else {
+                    // 通常のコピーの場合
+                    this.showNotification('success', 'コピー完了', `写真: ${result.copiedPhotos}ファイル, 動画: ${result.copiedVideos}ファイルのコピーが完了しました`);
+                }
             } else {
                 console.error(`コピーに失敗しました: ${result.message}`);
                 
-                // 上書き防止エラーの場合は専用メッセージを表示
+                // 上書き防止エラーの場合は専用メッセージを表示（後方互換性のため保持）
                 if (result.overwritePrevented) {
                     this.showNotification(
                         'error', 


### PR DESCRIPTION
## 概要
Issue #50 「既に同じフォルダがあったら不足分だけコピーしてほしい」に対応した差分コピー機能を実装しました。

## 主な変更内容

### 🆕 新機能
- **差分コピー機能**: 既存フォルダがある場合、不足分のファイルのみをコピー
- **既存ファイル保護**: 同名ファイルはスキップし、上書きを防止
- **詳細統計表示**: コピー数とスキップ数を分けて表示

### 🔧 技術的変更
- `checkForExistingFiles`関数を新規作成
- `copyFiles`関数を差分コピー対応に修正
- UIの通知メッセージを差分コピー対応に更新

### 🧪 TDD実装
- 差分コピー機能の包括的テストケースを追加
- 既存の上書き禁止テストを新仕様に合わせて更新
- **全18テストが正常に通過**

## 動作変更

### Before（旧仕様）
- 既存フォルダがある場合 → エラーで完全停止
- 「フォルダが既に存在します」メッセージ

### After（新仕様）
- 既存フォルダがある場合 → 差分コピー実行
- 詳細な統計表示（新規コピー数 + スキップ数）

## API変更

結果オブジェクトに新しいプロパティを追加：
```javascript
{
  success: true,
  copiedPhotos: 2,     // 既存
  copiedVideos: 1,     // 既存
  skippedPhotos: 1,    // ✨ 新規追加
  skippedVideos: 0,    // ✨ 新規追加
  alreadyExists: true  // ✨ 新規追加
}
```

## テストシナリオ

### ✅ 差分コピーの基本動作
- 既存フォルダに新しいファイルのみが追加される
- 既存ファイルは保護される

### ✅ 全ファイル既存の場合
- すべてスキップされ、適切な統計が表示される

### ✅ 混在パターン
- 写真は一部既存、動画は新規といった複雑なケースも正しく処理

## ユーザー体験の改善

1. **同日複数回撮影対応**: カメラで追加撮影後も安心してコピー可能
2. **明確なフィードバック**: 何がコピーされ、何がスキップされたかが一目で分かる
3. **データ保護**: 既存ファイルの誤上書きを完全に防止

## 後方互換性

- 新規フォルダへのコピーは従来通り動作
- 既存の設定やUIは変更なし
- エラーハンドリングロジックは維持

## 関連Issue

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)