### PR TITLE
fix: タイトルエリア削除とレスポンシブ対応でUI改善

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -9,10 +9,6 @@
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>📷 BF Copy <span id="app-version" class="version-display">v1.0.6</span></h1>
-        </header>
-
         <!-- 通知システム -->
         <div id="notification-container" class="notification-container"></div>
 
@@ -110,6 +106,11 @@
                         <div id="progress-text">0%</div>
                         <div id="progress-details"></div>
                     </section>
+
+                    <!-- バージョン表示 -->
+                    <div class="version-info">
+                        <span id="app-version" class="version-display">v1.0.9</span>
+                    </div>
                 </main>
             </div>
         </main>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -20,47 +20,23 @@ body {
     padding: 20px;
 }
 
-/* ヘッダー */
-header {
+/* バージョン表示 */
+.version-info {
     text-align: center;
-    color: #ffffff;
-    margin-bottom: 40px;
-    padding: 30px 0;
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 12px;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-header h1 {
-    font-size: 2.8rem;
-    margin-bottom: 15px;
-    text-shadow: 0 2px 8px rgba(0,0,0,0.5);
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    background: linear-gradient(135deg, #ffffff 0%, #e0e0e0 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
+    margin-top: 20px;
 }
 
 .version-display {
-    font-size: 0.4em;
+    font-size: 0.75rem;
     font-weight: 300;
-    opacity: 0.7;
-    vertical-align: top;
-    margin-left: 8px;
-    color: #cccccc;
-    -webkit-text-fill-color: #cccccc;
-    text-shadow: none;
+    color: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.05);
+    padding: 6px 12px;
+    border-radius: 6px;
+    backdrop-filter: blur(5px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-header p {
-    font-size: 1.2rem;
-    opacity: 0.85;
-    color: #cccccc;
-    font-weight: 300;
-}
 
 /* カード */
 .status-card {
@@ -637,7 +613,7 @@ button.primary:hover {
     display: grid;
     grid-template-columns: 450px 1fr;
     gap: 20px;
-    min-height: 700px;
+    min-height: 600px;
 }
 
 /* 左側サイドバー（フォルダリスト） */
@@ -665,7 +641,7 @@ button.primary:hover {
 #folder-sidebar .folder-list {
     flex: 1;
     overflow-y: auto;
-    max-height: 600px;
+    max-height: 500px;
     padding-right: 10px;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -613,7 +613,8 @@ button.primary:hover {
     display: grid;
     grid-template-columns: 450px 1fr;
     gap: 20px;
-    min-height: 600px;
+    height: calc(100vh - 320px);
+    min-height: 350px;
 }
 
 /* 左側サイドバー（フォルダリスト） */
@@ -627,6 +628,7 @@ button.primary:hover {
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    height: 100%;
 }
 
 #folder-sidebar h3 {
@@ -641,8 +643,8 @@ button.primary:hover {
 #folder-sidebar .folder-list {
     flex: 1;
     overflow-y: auto;
-    max-height: 500px;
     padding-right: 10px;
+    min-height: 0;
 }
 
 /* フォルダリストのコンパクト表示 */


### PR DESCRIPTION
## 概要
タイトルエリアを削除してUI領域を効率化し、フォルダ選択エリアをレスポンシブ対応しました。

## 変更内容
- ✅ 大きなタイトルヘッダーを削除してスペースを節約
- ✅ バージョン情報をメインエリア下部に移動（他要素との重複回避）
- ✅ フォルダ選択エリアを画面サイズに応じてレスポンシブ対応
- ✅ `calc(100vh - 320px)`でウィンドウサイズに適切にフィット
- ✅ サイドバーのフォルダリストが見切れる問題を解決

## 解決されるissue
- Fixes #47 タイトル場所取り過ぎ
- Fixes #48 サイドバーのフォルダが見きれている

## テスト計画
- [x] アプリケーション起動確認
- [x] バージョン情報の表示確認
- [x] フォルダ選択エリアのレスポンシブ動作確認
- [x] ウィンドウリサイズ時の適切な調整確認

🤖 Generated with [Claude Code](https://claude.ai/code)